### PR TITLE
feat(fix): discard abstract handlers in auto-registration

### DIFF
--- a/src/GSoft.CQRS.lutconfig
+++ b/src/GSoft.CQRS.lutconfig
@@ -1,0 +1,6 @@
+<LUTConfig Version="1.0">
+  <Repository />
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>

--- a/src/GSoft.Cqrs/Configuration/DependencyInjection/BuilderExtensions/CqrsBuilderExtensions.cs
+++ b/src/GSoft.Cqrs/Configuration/DependencyInjection/BuilderExtensions/CqrsBuilderExtensions.cs
@@ -43,6 +43,7 @@ public static class CqrsBuilderExtensions
         var typesToRegister =
             from assembly in assembliesToScan
             from type in assembly.GetTypes()
+            where !type.IsAbstract
             where typeFilter(type)
             where type.GetInterfaces().Any(i => i.IsGenericType && supportedHandlers.Contains(i.GetGenericTypeDefinition()))
             select type;


### PR DESCRIPTION
## Core changes
Ensure abstract handlers are discarded in the auto-registration process, since they can't be instantiated unless they are inherited from any concrete types

## Miscellaneous changes
Configure Visual Studio's Live Unit Testing for the current solution.
